### PR TITLE
Correct client log path for Linux

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -8,7 +8,7 @@
 
 | Operating System | Configuration File Path |
 | :----: | :----: |
-| Linux | /home/USERNAME/.config/mieru/client.conf.pb |
+| Linux | /home/$USER/.config/mieru/client.conf.pb |
 | Mac OS | /Users/USERNAME/Library/Application Support/mieru/client.conf.pb |
 | Windows | C:\Users\USERNAME\AppData\Roaming\mieru\client.conf.pb |
 
@@ -32,7 +32,7 @@ sudo journalctl -u mita --no-pager
 
 | Operating System | Configuration File Path |
 | :----: | :----: |
-| Linux | /home/USERNAME/.cache/mieru/ |
+| Linux | /home/$USER/.config/.cache/mieru/ |
 | Mac OS | /Users/USERNAME/Library/Caches/mieru/ |
 | Windows | C:\Users\USERNAME\AppData\Local\mieru\ |
 


### PR DESCRIPTION
On Linux (Debian sid here), client log file is stored at `~/.config/cache/mieru/`