### PR TITLE
Replace C:\Users\USERNAME with %USERPROFILE%

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -10,7 +10,7 @@ The configuration file of the mieru client is also a binary file. It is stored i
 | :----: | :----: |
 | Linux | $HOME/.config/mieru/client.conf.pb |
 | Mac OS | /Users/USERNAME/Library/Application Support/mieru/client.conf.pb |
-| Windows | C:\Users\USERNAME\AppData\Roaming\mieru\client.conf.pb |
+| Windows | %USERPROFILE%\AppData\Roaming\mieru\client.conf.pb |
 
 ## View mita proxy server log
 

--- a/docs/operation.zh_CN.md
+++ b/docs/operation.zh_CN.md
@@ -10,7 +10,7 @@
 | :----: | :----: |
 | Linux | $HOME/.config/mieru/client.conf.pb |
 | Mac OS | /Users/USERNAME/Library/Application Support/mieru/client.conf.pb |
-| Windows | C:\Users\USERNAME\AppData\Roaming\mieru\client.conf.pb |
+| Windows | %USERPROFILE%\AppData\Roaming\mieru\client.conf.pb |
 
 ## 查看代理服务器 mita 的日志
 


### PR DESCRIPTION
to prevent some users' home folders from being outside the Users folder.