### PR TITLE
docs: add ClashFest to third-party Android clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The mieru proxy software suite consists of two parts, a client software called m
   - [husi](https://github.com/xchacha20-poly1305/husi) + [mieru plugin](https://github.com/xchacha20-poly1305/husi/releases?q=plugin-mieru)
   - [Karing](https://karing.app/)
   - [NekoBoxForAndroid](https://github.com/MatsuriDayo/NekoBoxForAndroid) + [mieru plugin](https://github.com/enfein/NekoBoxPlugins)
+  - [ClashFest](https://github.com/Nemu-x/ClashFest)
 - iOS
   - [ClashMi](https://clashmi.app/)
   - [Karing](https://karing.app/)


### PR DESCRIPTION
### Summary
Adds **[ClashFest](https://github.com/Nemu-x/ClashFest)** to the *Third Party Client Software → Android* list.

ClashFest is an Android client in the Clash Meta / Mihomo family (forked from the CMFA lineage). It supports importing **`mierus://`** subscription links through the same flow as HTTP(S) subscriptions (including **QR scan** and **clipboard**), backed by the Mihomo stack.

### Verification
Manually tested against a real **mita** server: import succeeds and the profile runs as expected.

### Release note (optional)
See release **v0.4.2**: https://github.com/Nemu-x/ClashFest/releases/tag/v0.4.2 - includes mierus subscription support.

Happy to adjust wording or list placement to match your README style.