### PR TITLE
docs: add SlothClash to third-party desktop clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The mieru proxy software suite consists of two parts, a client software called m
   - [Clash Verge Rev](https://www.clashverge.dev/)
   - [Mihomo Party](https://mihomo.party/)
   - [NyameBox](https://qr243vbi.github.io/nekobox/#/) - a fork of NekoBox
+  - [SlothClash](https://github.com/Nemu-x/SlothClash)
 - Android
   - [ClashFest](https://github.com/Nemu-x/ClashFest)
   - [ClashMetaForAndroid](https://github.com/MetaCubeX/ClashMetaForAndroid)


### PR DESCRIPTION
## Summary
Adds SlothClash to the Third Party Client Software → Desktop list.

SlothClash is a Wails + Mihomo desktop client for Windows / macOS / Linux. It supports `mieru://` / `mierus://` as a profile subscription URL (paste into the profile field): the app turns that into inline Mihomo mieru proxy YAML for the core, same overall idea as the Clash Verge Rev flow in your docs.

### Verification
Manually tested against a real mieru server: import succeeds and the profile runs as expected.

### Release note
See release v0.3.0: https://github.com/Nemu-x/SlothClash/releases/tag/v0.3.0 — includes mieru:// / mierus:// subscription handling.
