### PR TITLE
feat: harden anti-detection by fixing entropy padding and randomizing heartbeat

### DIFF
--- a/pkg/protocol/session.go
+++ b/pkg/protocol/session.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	mrand "math/rand"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -135,6 +136,7 @@ type Session struct {
 	lastSend               atomic.Uint32 // last segment sequence number sent
 	lastRXTime             atomic.Int64  // last timestamp when a segment is received, in microseconds since Unix epoch
 	lastTXTime             atomic.Int64  // last timestamp when a segment is sent, in microseconds since Unix epoch
+	heartbeatJitter        time.Duration // random jitter added to heartbeat interval to break periodic pattern
 	nextRetransmissionTime atomic.Int64  // time that need to retransmit a segment in sendBuf, in microseconds since Unix epoch
 	ackOnDataRecv          atomic.Bool   // whether ack should be sent due to receive of new data
 	unreadBuf              []byte        // payload removed from the recvQueue that haven't been read by application
@@ -189,6 +191,9 @@ func NewSession(id uint32, isClient bool, mtu int, users map[string]*appctlpb.Us
 	now := time.Now().UnixMicro()
 	s.lastRXTime.Store(now)
 	s.lastTXTime.Store(now)
+	// Add random jitter of [-2s, +2s] to heartbeat interval to prevent
+	// pattern detection based on the fixed 5-second cycle.
+	s.heartbeatJitter = time.Duration(mrand.Intn(5)-2) * time.Second
 	s.remoteWindowSize.Store(minWindowSize)
 	return s
 }
@@ -829,7 +834,8 @@ func (s *Session) runOutputOncePacket() {
 
 	// Send ACK or heartbeat if needed.
 	// ACK is not limited by window.
-	exceedHeartbeatInterval := time.Now().UnixMicro()-s.lastTXTime.Load() > sessionHeartbeatInterval.Microseconds()
+	jitteredInterval := sessionHeartbeatInterval + s.heartbeatJitter
+	exceedHeartbeatInterval := time.Now().UnixMicro()-s.lastTXTime.Load() > jitteredInterval.Microseconds()
 	if s.ackOnDataRecv.Load() || exceedHeartbeatInterval {
 		baseStruct := baseStruct{}
 		if s.isClient {
@@ -858,6 +864,8 @@ func (s *Session) runOutputOncePacket() {
 			s.closeWithError(err)
 		}
 		s.ackOnDataRecv.Store(false)
+		// Re-randomize jitter after each heartbeat to further break periodicity.
+		s.heartbeatJitter = time.Duration(mrand.Intn(5)-2) * time.Second
 	}
 }
 


### PR DESCRIPTION
## Summary

Two targeted changes in the shared protocol layer to make mieru traffic significantly harder to detect through statistical analysis and pattern matching.

### 1. Fix entropy padding statistical fingerprint

Changed the target bit probability from a fixed `0.325` to a random value in `[0.47, 0.53]` (per-host). The original 0.325 target created a detectable deviation from 50% — the natural distribution of encrypted data. The new range makes bit distribution indistinguishable from normal encrypted traffic (TLS/SSH), eliminating the most prominent statistical fingerprint.

**File:** `pkg/protocol/padding.go` — 1 line change

### 2. Randomize heartbeat interval

Added `[-2s, +2s]` random jitter to the fixed 5-second heartbeat interval, making the actual cycle irregular (3–7 seconds). Jitter is re-generated after each heartbeat to prevent periodic pattern detection.

**File:** `pkg/protocol/session.go` — ~5 lines change

### Compatibility

- Both changes affect outbound traffic construction only; the receiving side needs no modification.
- Protocol format is unchanged. An updated client works with an unmodified server, and vice versa.
- Upgrading both sides maximizes the effect (bidirectional traffic hardened).

