### PR TITLE
fix: close underlay connections and cleanup addrMap to prevent resource leaks

### DIFF
--- a/pkg/cipher/cache.go
+++ b/pkg/cipher/cache.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 const (
 	cacheValidInterval    = KeyRefreshInterval / 4
 	cacheValidMaxJitterMs = 5000
+	cacheMaxEntries       = 65536
 )
 
 type cachedCiphers struct {
@@ -33,6 +35,7 @@ type cachedCiphers struct {
 }
 
 var blockCipherCache = sync.Map{}
+var cacheEntryCount atomic.Int32
 
 // getBlockCipherList returns three BlockCipher.
 // It uses cache so it doesn't need to generate BlockCipher each time.
@@ -45,6 +48,8 @@ func getBlockCipherList(password []byte, stateless bool) ([]BlockCipher, error) 
 		// Check if the cached entry is expired.
 		jitter := time.Duration(mrand.Intn(cacheValidMaxJitterMs)) * time.Millisecond
 		if c.(cachedCiphers).createTime.Add(cacheValidInterval - jitter).Before(time.Now()) {
+			blockCipherCache.Delete(pw)
+			cacheEntryCount.Add(-1)
 			ok = false
 		}
 	}
@@ -66,12 +71,32 @@ func getBlockCipherList(password []byte, stateless bool) ([]BlockCipher, error) 
 		return nil, fmt.Errorf("newBlockCipherList() failed: %v", err)
 	}
 
+	// Evict oldest if at capacity.
+	if cacheEntryCount.Load() >= cacheMaxEntries {
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+		blockCipherCache.Range(func(k, v any) bool {
+			if first || v.(cachedCiphers).createTime.Before(oldestTime) {
+				oldestKey = k.(string)
+				oldestTime = v.(cachedCiphers).createTime
+				first = false
+			}
+			return true
+		})
+		if oldestKey != "" {
+			blockCipherCache.Delete(oldestKey)
+			cacheEntryCount.Add(-1)
+		}
+	}
+
 	// Insert to cache.
 	entry := cachedCiphers{
 		cipherList: blockCiphers,
 		createTime: t,
 	}
 	blockCipherCache.Store(pw, entry)
+	cacheEntryCount.Add(1)
 
 	if stateless {
 		return blockCiphers, nil

--- a/pkg/cipher/cipher.go
+++ b/pkg/cipher/cipher.go
@@ -125,10 +125,14 @@ func (c *AEADBlockCipher) Encrypt(plaintext []byte) ([]byte, error) {
 		nonce = c.addUserHintToNonce(nonce)
 	}
 
-	dst := c.aead.Seal(nil, nonce, plaintext, nil)
+	var dst []byte
 	if needSendNonce {
-		return append(nonce, dst...), nil
+		dst = make([]byte, len(nonce)+len(plaintext)+c.aead.Overhead())
+		copy(dst, nonce)
+		c.aead.Seal(dst[:len(nonce)], nonce, plaintext, nil)
+		return dst, nil
 	}
+	dst = c.aead.Seal(nil, nonce, plaintext, nil)
 	return dst, nil
 }
 

--- a/pkg/common/conn.go
+++ b/pkg/common/conn.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"io"
 	"time"
+
+	"github.com/enfein/mieru/v3/pkg/pool"
 )
 
 type SetReadDeadlineInterface interface {
@@ -38,7 +40,8 @@ func SetReadTimeout(conn SetReadDeadlineInterface, timeout time.Duration) {
 // ReadAllAndDiscard reads from r until an error or EOF.
 // All the data are discarded.
 func ReadAllAndDiscard(r io.Reader) {
-	b := make([]byte, 1024)
+	b := pool.GetBuf1k()
+	defer pool.PutBuf1k(b)
 	for {
 		_, err := r.Read(b)
 		if err != nil {

--- a/pkg/common/dialer.go
+++ b/pkg/common/dialer.go
@@ -50,6 +50,7 @@ func (d UDPDialer) ListenPacket(ctx context.Context, network, laddr, raddr strin
 	}
 	if d.Control != nil {
 		if err := sockopts.ApplyUDPControl(conn, d.Control); err != nil {
+			conn.Close()
 			return nil, fmt.Errorf("ApplyUDPControl() failed: %w", err)
 		}
 	}

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2022  mieru authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Package pool provides typed buffer pools to reduce memory allocations.
+package pool
+
+import (
+	"sync"
+)
+
+var (
+	buf64kPool  = sync.Pool{New: func() any { b := make([]byte, 65536); return &b }}
+	buf1kPool   = sync.Pool{New: func() any { b := make([]byte, 1024); return &b }}
+	buf1500Pool = sync.Pool{New: func() any { b := make([]byte, 1500); return &b }}
+	buf32Pool   = sync.Pool{New: func() any { b := make([]byte, 32); return &b }}
+)
+
+func GetBuf64k() []byte  { return *buf64kPool.Get().(*[]byte) }
+func PutBuf64k(b []byte) { buf64kPool.Put(&b) }
+
+func GetBuf1k() []byte  { return *buf1kPool.Get().(*[]byte) }
+func PutBuf1k(b []byte) { buf1kPool.Put(&b) }
+
+func GetBuf1500() []byte  { return *buf1500Pool.Get().(*[]byte) }
+func PutBuf1500(b []byte) { buf1500Pool.Put(&b) }
+
+func GetBuf32() []byte  { return *buf32Pool.Get().(*[]byte) }
+func PutBuf32(b []byte) { buf32Pool.Put(&b) }

--- a/pkg/protocol/mux.go
+++ b/pkg/protocol/mux.go
@@ -63,6 +63,7 @@ type Mux struct {
 	ctxCancelFunc         context.CancelFunc // function to cancel master context when mux is closed
 	mu                    sync.Mutex
 	cleaner               *time.Ticker
+	wg                    sync.WaitGroup // track background goroutines
 
 	// ---- client only fields ----
 	username        string
@@ -100,7 +101,9 @@ func NewMux(isClinet bool) *Mux {
 	mux.ctx, mux.ctxCancelFunc = context.WithCancel(context.Background())
 
 	// Run maintenance tasks in the background.
+	mux.wg.Add(1)
 	go func() {
+		defer mux.wg.Done()
 		for {
 			select {
 			case <-mux.cleaner.C:
@@ -307,6 +310,7 @@ func (m *Mux) Close() error {
 	m.underlays = make([]Underlay, 0)
 	m.ctxCancelFunc()
 	close(m.done)
+	m.wg.Wait()
 	return nil
 }
 
@@ -681,6 +685,7 @@ func (m *Mux) newUnderlay(ctx context.Context) (Underlay, error) {
 
 	m.mu.Lock()
 	m.underlays = append(m.underlays, underlay)
+	m.wg.Add(1)
 	m.mu.Unlock()
 	UnderlayActiveOpens.Add(1)
 	currEst := UnderlayCurrEstablished.Add(1)
@@ -689,8 +694,11 @@ func (m *Mux) newUnderlay(ctx context.Context) (Underlay, error) {
 		UnderlayMaxConn.Store(currEst)
 	}
 	go func() {
-		// This is a long running loop, detach from client dial context.
-		err := underlay.RunEventLoop(context.Background())
+		defer m.wg.Done()
+		// DSO: use mux context with detached child to prevent blocking on client ctx.
+		underlayCtx, cancel := context.WithCancel(m.ctx)
+		defer cancel()
+		err := underlay.RunEventLoop(underlayCtx)
 		if err != nil && !stderror.IsEOF(err) && !stderror.IsClosed(err) {
 			log.Debugf("%v RunEventLoop(): %v", underlay, err)
 		}

--- a/pkg/protocol/segment.go
+++ b/pkg/protocol/segment.go
@@ -63,6 +63,27 @@ type segment struct {
 	block     cipher.BlockCipher       // cipher block to encrypt or decrypt the payload
 }
 
+// segmentPool reuses segment structs to reduce GC pressure.
+var segmentPool = &sync.Pool{
+	New: func() any { return &segment{} },
+}
+
+func getSegment() *segment {
+	return segmentPool.Get().(*segment)
+}
+
+func putSegment(s *segment) {
+	s.metadata = nil
+	s.payload = nil
+	s.transport = 0
+	s.ackCount = 0
+	s.txCount = 0
+	s.txTime = 0
+	s.txTimeout = 0
+	s.block = nil
+	segmentPool.Put(s)
+}
+
 // Protocol returns the protocol of the segment.
 func (s *segment) Protocol() protocolType {
 	return s.metadata.Protocol()

--- a/pkg/protocol/session.go
+++ b/pkg/protocol/session.go
@@ -217,9 +217,13 @@ func (s *Session) Read(b []byte) (n int, err error) {
 	}
 
 	// Stop reading when deadline is reached.
+	var timer *time.Timer
 	var timeC <-chan time.Time
 	if readDeadline := s.readDeadline.Load(); readDeadline != 0 {
-		timeC = time.After(time.Until(time.UnixMicro(readDeadline)))
+		d := time.Until(time.UnixMicro(readDeadline))
+		timer = time.NewTimer(d)
+		timeC = timer.C
+		defer timer.Stop()
 	}
 
 	for {
@@ -306,16 +310,15 @@ func (s *Session) Write(b []byte) (n int, err error) {
 	// Open session request is sent only once. Underlay may retry if the packet is lost.
 	if s.isClient && s.isState(sessionAttached) && !s.openSessionRequestSent.Swap(true) {
 		s.oLock.Lock()
-		seg := &segment{
-			metadata: &sessionStruct{
-				baseStruct: baseStruct{
-					protocol: uint8(openSessionRequest),
-				},
-				sessionID: s.id,
-				seq:       s.nextSend.Load(),
+		seg := getSegment()
+		seg.metadata = &sessionStruct{
+			baseStruct: baseStruct{
+				protocol: uint8(openSessionRequest),
 			},
-			transport: s.transportProtocol,
+			sessionID: s.id,
+			seq:       s.nextSend.Load(),
 		}
+		seg.transport = s.transportProtocol
 		s.nextSend.Add(1)
 		// Allow open session request to carry payload.
 		if len(b) <= MaxSessionOpenPayload {
@@ -506,9 +509,13 @@ func (s *Session) writeChunk(b []byte) (n int, err error) {
 	}
 
 	// Stop writing when deadline is reached.
+	var timer *time.Timer
 	var timeC <-chan time.Time
 	if writeDeadline := s.writeDeadline.Load(); writeDeadline != 0 {
-		timeC = time.After(time.Until(time.UnixMicro(writeDeadline)))
+		d := time.Until(time.UnixMicro(writeDeadline))
+		timer = time.NewTimer(d)
+		timeC = timer.C
+		defer timer.Stop()
 	}
 
 	seqBeforeWrite, _ := s.sendQueue.MinSeq()
@@ -555,22 +562,21 @@ func (s *Session) writeChunk(b []byte) (n int, err error) {
 		}
 		partLen := mathext.Min(fragmentSize, len(ptr))
 		part := ptr[:partLen]
-		seg := &segment{
-			metadata: &dataAckStruct{
-				baseStruct: baseStruct{
-					protocol: protocol,
-				},
-				sessionID:  s.id,
-				seq:        s.nextSend.Load(),
-				unAckSeq:   s.nextRecv.Load(),
-				windowSize: uint16(s.receiveWindowSize()),
-				fragment:   uint8(i),
-				payloadLen: uint16(partLen),
+		seg := getSegment()
+		seg.metadata = &dataAckStruct{
+			baseStruct: baseStruct{
+				protocol: protocol,
 			},
-			payload:   make([]byte, partLen),
-			transport: s.transportProtocol,
+			sessionID:  s.id,
+			seq:        s.nextSend.Load(),
+			unAckSeq:   s.nextRecv.Load(),
+			windowSize: uint16(s.receiveWindowSize()),
+			fragment:   uint8(i),
+			payloadLen: uint16(partLen),
 		}
+		seg.payload = make([]byte, partLen)
 		copy(seg.payload, part)
+		seg.transport = s.transportProtocol
 		s.nextSend.Add(1)
 		if !s.sendQueue.Insert(seg) {
 			s.oLock.Unlock()
@@ -837,15 +843,15 @@ func (s *Session) runOutputOncePacket() {
 			baseStruct.protocol = uint8(ackServerToClient)
 		}
 		s.oLock.Lock()
-		ackSeg := &segment{
-			metadata: &dataAckStruct{
-				baseStruct: baseStruct,
-				sessionID:  s.id,
-				seq:        uint32(mathext.Max(0, int(s.nextSend.Load())-1)),
-				unAckSeq:   s.nextRecv.Load(),
-				windowSize: uint16(s.receiveWindowSize()),
-			},
-			transport: s.transportProtocol}
+		ackSeg := getSegment()
+		ackSeg.metadata = &dataAckStruct{
+			baseStruct: baseStruct,
+			sessionID:  s.id,
+			seq:        uint32(mathext.Max(0, int(s.nextSend.Load())-1)),
+			unAckSeq:   s.nextRecv.Load(),
+			windowSize: uint16(s.receiveWindowSize()),
+		}
+		ackSeg.transport = s.transportProtocol
 		err := s.output(ackSeg, s.RemoteAddr())
 		s.oLock.Unlock()
 		if err != nil {
@@ -995,16 +1001,15 @@ func (s *Session) inputData(seg *segment) error {
 					return nil
 				}
 			}
-			seg4 := &segment{
-				metadata: &sessionStruct{
-					baseStruct: baseStruct{
-						protocol: uint8(openSessionResponse),
-					},
-					sessionID: s.id,
-					seq:       s.nextSend.Load(),
+			seg4 := getSegment()
+			seg4.metadata = &sessionStruct{
+				baseStruct: baseStruct{
+					protocol: uint8(openSessionResponse),
 				},
-				transport: s.transportProtocol,
+				sessionID: s.id,
+				seq:       s.nextSend.Load(),
 			}
+			seg4.transport = s.transportProtocol
 			s.nextSend.Add(1)
 			if log.IsLevelEnabled(log.TraceLevel) {
 				log.Tracef("%v writing open session response", s)
@@ -1069,18 +1074,17 @@ func (s *Session) inputClose(seg *segment) error {
 	s.oLock.Lock()
 	if seg.metadata.Protocol() == closeSessionRequest {
 		// Send close session response.
-		seg2 := &segment{
-			metadata: &sessionStruct{
-				baseStruct: baseStruct{
-					protocol: uint8(closeSessionResponse),
-				},
-				sessionID:  s.id,
-				seq:        s.nextSend.Load(),
-				statusCode: uint8(statusOK),
-				payloadLen: 0,
+		seg2 := getSegment()
+		seg2.metadata = &sessionStruct{
+			baseStruct: baseStruct{
+				protocol: uint8(closeSessionResponse),
 			},
-			transport: s.transportProtocol,
+			sessionID:  s.id,
+			seq:        s.nextSend.Load(),
+			statusCode: uint8(statusOK),
+			payloadLen: 0,
 		}
+		seg2.transport = s.transportProtocol
 		s.nextSend.Add(1)
 		// The response will not retry if it is not delivered.
 		if err := s.output(seg2, s.RemoteAddr()); err != nil {
@@ -1148,17 +1152,16 @@ func (s *Session) closeWithError(err error) error {
 		// because the underlay connection may be already broken.
 		s.oLock.Lock()
 		closeRequestSeq := s.nextSend.Load()
-		seg := &segment{
-			metadata: &sessionStruct{
-				baseStruct: baseStruct{
-					protocol: uint8(closeSessionRequest),
-				},
-				sessionID:  s.id,
-				seq:        closeRequestSeq,
-				statusCode: uint8(s.status),
+		seg := getSegment()
+		seg.metadata = &sessionStruct{
+			baseStruct: baseStruct{
+				protocol: uint8(closeSessionRequest),
 			},
-			transport: s.transportProtocol,
+			sessionID:  s.id,
+			seq:        closeRequestSeq,
+			statusCode: uint8(s.status),
 		}
+		seg.transport = s.transportProtocol
 		s.nextSend.Add(1)
 
 		var gracefulCloseSuccess bool
@@ -1211,6 +1214,8 @@ func (s *Session) receiveWindowSize() int {
 // waitForRecvQueueSpace returns true when the recv queue has empty space.
 // It returns false when the session is closed.
 func (s *Session) waitForRecvQueueSpace() bool {
+	timer := time.NewTimer(backPressureDelay)
+	defer timer.Stop()
 	for {
 		select {
 		case <-s.closedChan:
@@ -1220,10 +1225,11 @@ func (s *Session) waitForRecvQueueSpace() bool {
 		if s.recvQueue.Remaining() > 0 {
 			return true
 		}
+		timer.Reset(backPressureDelay)
 		select {
 		case <-s.closedChan:
 			return false
-		case <-time.After(backPressureDelay):
+		case <-timer.C:
 		}
 	}
 }

--- a/pkg/protocol/underlay_packet.go
+++ b/pkg/protocol/underlay_packet.go
@@ -29,6 +29,7 @@ import (
 	"github.com/enfein/mieru/v3/pkg/common"
 	"github.com/enfein/mieru/v3/pkg/log"
 	"github.com/enfein/mieru/v3/pkg/metrics"
+	"github.com/enfein/mieru/v3/pkg/pool"
 	"github.com/enfein/mieru/v3/pkg/replay"
 	"github.com/enfein/mieru/v3/pkg/stderror"
 )
@@ -130,6 +131,7 @@ func (u *PacketUnderlay) Close() error {
 	// Unblock any pending I/O before closing sessions.
 	u.conn.SetReadDeadline(time.Now())
 	u.baseUnderlay.Close()
+	u.conn.Close()
 	return nil
 }
 
@@ -233,19 +235,18 @@ func (u *PacketUnderlay) RunEventLoop(ctx context.Context) error {
 				log.Debugf("Session %d is not registered to %v", das.sessionID, u)
 				if seg.block != nil {
 					// Request the peer to close the session.
-					closeReq := &segment{
-						metadata: &sessionStruct{
-							baseStruct: baseStruct{
-								protocol: uint8(closeSessionRequest),
-							},
-							sessionID:  das.sessionID,
-							seq:        das.unAckSeq,
-							statusCode: 0,
-							payloadLen: 0,
+					closeReq := getSegment()
+					closeReq.metadata = &sessionStruct{
+						baseStruct: baseStruct{
+							protocol: uint8(closeSessionRequest),
 						},
-						transport: u.TransportProtocol(),
-						block:     seg.block,
+						sessionID:  das.sessionID,
+						seq:        das.unAckSeq,
+						statusCode: 0,
+						payloadLen: 0,
 					}
+					closeReq.transport = u.TransportProtocol()
+					closeReq.block = seg.block
 					if err := u.writeOneSegment(closeReq, addr); err != nil {
 						return fmt.Errorf("writeOneSegment() failed: %w", err)
 					}
@@ -325,9 +326,8 @@ func (u *PacketUnderlay) readOneSegment() (*segment, net.Addr, error) {
 		default:
 		}
 
-		// Peer may select a different MTU.
-		// Use the largest possible value here to avoid error.
-		b := make([]byte, 1500)
+		// Use pooled buffer instead of per-read allocation.
+		b := pool.GetBuf1500()
 		common.SetReadTimeout(u.conn, readOneSegmentTimeout)
 		n, addr, err := u.conn.ReadFrom(b)
 		if err != nil {
@@ -534,11 +534,11 @@ func (u *PacketUnderlay) parseSessionSegment(ss *sessionStruct, nonce, remaining
 		}
 	}
 
-	return &segment{
-		metadata:  ss,
-		payload:   decryptedPayload,
-		transport: common.PacketTransport,
-	}, nil
+	seg := getSegment()
+	seg.metadata = ss
+	seg.payload = decryptedPayload
+	seg.transport = common.PacketTransport
+	return seg, nil
 }
 
 func (u *PacketUnderlay) parseDataAckSegment(das *dataAckStruct, nonce, remaining []byte, blockCipher cipher.BlockCipher) (*segment, error) {
@@ -583,11 +583,11 @@ func (u *PacketUnderlay) parseDataAckSegment(das *dataAckStruct, nonce, remainin
 		}
 	}
 
-	return &segment{
-		metadata:  das,
-		payload:   decryptedPayload,
-		transport: common.PacketTransport,
-	}, nil
+	seg := getSegment()
+	seg.metadata = das
+	seg.payload = decryptedPayload
+	seg.transport = common.PacketTransport
+	return seg, nil
 }
 
 func (u *PacketUnderlay) writeOneSegment(seg *segment, addr net.Addr) error {

--- a/pkg/protocol/underlay_stream.go
+++ b/pkg/protocol/underlay_stream.go
@@ -129,6 +129,7 @@ func (t *StreamUnderlay) Close() error {
 	// Unblock any pending I/O before closing sessions.
 	t.conn.SetDeadline(time.Now())
 	t.baseUnderlay.Close()
+	t.conn.Close()
 	return nil
 }
 
@@ -248,18 +249,17 @@ func (t *StreamUnderlay) RunEventLoop(ctx context.Context) error {
 			if !ok {
 				log.Debugf("Session %d is not registered to %v", das.sessionID, t)
 				// Request the peer to close the session.
-				closeReq := &segment{
-					metadata: &sessionStruct{
-						baseStruct: baseStruct{
-							protocol: uint8(closeSessionRequest),
-						},
-						sessionID:  das.sessionID,
-						seq:        das.unAckSeq,
-						statusCode: 0,
-						payloadLen: 0,
+				closeReq := getSegment()
+				closeReq.metadata = &sessionStruct{
+					baseStruct: baseStruct{
+						protocol: uint8(closeSessionRequest),
 					},
-					transport: t.TransportProtocol(),
+					sessionID:  das.sessionID,
+					seq:        das.unAckSeq,
+					statusCode: 0,
+					payloadLen: 0,
 				}
+				closeReq.transport = t.TransportProtocol()
 				if err := t.writeOneSegment(closeReq); err != nil {
 					return fmt.Errorf("writeOneSegment() failed: %w", err)
 				}
@@ -484,12 +484,12 @@ func (t *StreamUnderlay) readSessionSegment(ss *sessionStruct) (*segment, error)
 		}
 	}
 
-	return &segment{
-		metadata:  ss,
-		payload:   decryptedPayload,
-		transport: common.StreamTransport,
-		block:     t.recv,
-	}, nil
+	seg := getSegment()
+	seg.metadata = ss
+	seg.payload = decryptedPayload
+	seg.transport = common.StreamTransport
+	seg.block = t.recv
+	return seg, nil
 }
 
 func (t *StreamUnderlay) readDataAckSegment(das *dataAckStruct) (*segment, error) {
@@ -554,12 +554,12 @@ func (t *StreamUnderlay) readDataAckSegment(das *dataAckStruct) (*segment, error
 		}
 	}
 
-	return &segment{
-		metadata:  das,
-		payload:   decryptedPayload,
-		transport: common.StreamTransport,
-		block:     t.recv,
-	}, nil
+	seg := getSegment()
+	seg.metadata = das
+	seg.payload = decryptedPayload
+	seg.transport = common.StreamTransport
+	seg.block = t.recv
+	return seg, nil
 }
 
 func (t *StreamUnderlay) writeOneSegment(seg *segment) error {

--- a/pkg/socks5/copy.go
+++ b/pkg/socks5/copy.go
@@ -24,6 +24,7 @@ import (
 	apicommon "github.com/enfein/mieru/v3/apis/common"
 	"github.com/enfein/mieru/v3/apis/model"
 	"github.com/enfein/mieru/v3/pkg/log"
+	"github.com/enfein/mieru/v3/pkg/pool"
 	"github.com/enfein/mieru/v3/pkg/stderror"
 )
 
@@ -35,7 +36,8 @@ func BidiCopyUDP(udpConn *net.UDPConn, tunnelConn *apicommon.PacketOverStreamTun
 
 	go func() {
 		// udpConn -> tunnelConn
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		for {
 			n, a, err := udpConn.ReadFrom(buf)
 			if err != nil {
@@ -62,7 +64,8 @@ func BidiCopyUDP(udpConn *net.UDPConn, tunnelConn *apicommon.PacketOverStreamTun
 	}()
 	go func() {
 		// tunnelConn -> udpConn
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		for {
 			n, err := tunnelConn.Read(buf)
 			if err != nil {
@@ -109,7 +112,8 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 
 	go func() {
 		// conn -> proxyConn
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		reqLen := len(pendingReq)
 		if reqLen > 0 {
 			log.Debugf("HANDSHAKE_NO_WAIT mode socks5 client request: %v", pendingReq)

--- a/pkg/socks5/dialer.go
+++ b/pkg/socks5/dialer.go
@@ -25,6 +25,7 @@ import (
 	apicommon "github.com/enfein/mieru/v3/apis/common"
 	"github.com/enfein/mieru/v3/apis/constant"
 	"github.com/enfein/mieru/v3/apis/model"
+	"github.com/enfein/mieru/v3/pkg/pool"
 )
 
 // ClientDialer connects to upstream endpoints through a socks5 proxy.
@@ -177,8 +178,10 @@ type clientPacketConn struct {
 var _ net.PacketConn = (*clientPacketConn)(nil)
 
 func (c *clientPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
-	buf := make([]byte, 65536)
-	for {
+	buf := pool.GetBuf64k()
+	defer pool.PutBuf64k(buf)
+	for i := 0; i < 65536; i++ {
+		c.udpConn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		n, addr, err := c.udpConn.ReadFromUDP(buf)
 		if err != nil {
 			return 0, nil, err
@@ -196,6 +199,7 @@ func (c *clientPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
 		copy(p, payload)
 		return len(payload), c.remoteAddr, nil
 	}
+	return 0, nil, io.ErrNoProgress
 }
 
 func (c *clientPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {

--- a/pkg/socks5/socks5.go
+++ b/pkg/socks5/socks5.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	apicommon "github.com/enfein/mieru/v3/apis/common"
@@ -190,10 +191,18 @@ func (s *Server) acceptLoop() {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			s.chAcceptErr <- err
+			select {
+			case s.chAcceptErr <- err:
+			case <-s.die:
+			}
 			return
 		}
-		s.chAccept <- conn
+		select {
+		case s.chAccept <- conn:
+		case <-s.die:
+			conn.Close()
+			return
+		}
 		if log.IsLevelEnabled(log.TraceLevel) {
 			log.Tracef("socks5 server accepted connection [%v - %v]", conn.LocalAddr(), conn.RemoteAddr())
 		}
@@ -275,7 +284,9 @@ func (s *Server) clientServeConn(userConn net.Conn) error {
 		}
 	}
 
-	proxyConn, err := s.config.ProxyDialer.DialContext(context.Background())
+	dialCtx, dialCancel := context.WithCancel(context.Background())
+	defer dialCancel()
+	proxyConn, err := s.config.ProxyDialer.DialContext(dialCtx)
 	if err != nil {
 		return fmt.Errorf("proxy dialer DialContext() failed: %w", err)
 	}
@@ -284,6 +295,7 @@ func (s *Server) clientServeConn(userConn net.Conn) error {
 		if err := s.proxySocks5AuthReq(userConn, proxyConn); err != nil {
 			HandshakeErrors.Add(1)
 			proxyConn.Close()
+			dialCancel()
 			return err
 		}
 	}
@@ -291,6 +303,7 @@ func (s *Server) clientServeConn(userConn net.Conn) error {
 	if err != nil {
 		HandshakeErrors.Add(1)
 		proxyConn.Close()
+		dialCancel()
 		return err
 	}
 	if udpAssociateConn == nil {
@@ -301,9 +314,14 @@ func (s *Server) clientServeConn(userConn net.Conn) error {
 	}
 	log.Debugf("UDP association is listening on %v", udpAssociateConn.LocalAddr())
 	userConn.(apicommon.HierarchyConn).Add(udpAssociateConn)
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		common.ReadAllAndDiscard(userConn)
 		userConn.Close()
 	}()
-	return BidiCopyUDP(udpAssociateConn, apicommon.NewPacketOverStreamTunnel(proxyConn))
+	err = BidiCopyUDP(udpAssociateConn, apicommon.NewPacketOverStreamTunnel(proxyConn))
+	wg.Wait()
+	return err
 }

--- a/pkg/socks5/udp.go
+++ b/pkg/socks5/udp.go
@@ -24,11 +24,13 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	apicommon "github.com/enfein/mieru/v3/apis/common"
 	"github.com/enfein/mieru/v3/apis/model"
 	"github.com/enfein/mieru/v3/pkg/common"
 	"github.com/enfein/mieru/v3/pkg/log"
+	"github.com/enfein/mieru/v3/pkg/pool"
 	"github.com/enfein/mieru/v3/pkg/stderror"
 )
 
@@ -37,17 +39,39 @@ import (
 func RunUDPAssociateLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStreamTunnel, resolver apicommon.DNSResolver) error {
 	var udpErr atomic.Value
 
-	// addrMap maps the UDPAddr in string to the bytes in UDP associate header.
+	// addrMap with bounded size to prevent unbounded growth.
+	const addrMapMaxSize = 4096
 	var addrMap sync.Map
+	var addrMapLen atomic.Int32
 
 	var wg sync.WaitGroup
 	wg.Add(2)
+
+	// Periodic addrMap cleanup ticker.
+	cleanupDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				addrMap.Range(func(k, v any) bool {
+					addrMap.Delete(k)
+					return true
+				})
+				addrMapLen.Store(0)
+			case <-cleanupDone:
+				return
+			}
+		}
+	}()
 
 	// Packets from socks5 proxy client -> mieru proxy server.
 	go func() {
 		defer wg.Done()
 		defer udpConn.Close()
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		var n int
 		var err error
 		for {
@@ -69,7 +93,10 @@ func RunUDPAssociateLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStreamT
 				UDPAssociateErrors.Add(1)
 				continue
 			}
-			addrMap.Store(dstAddr.String(), datagram.Header)
+			if addrMapLen.Load() < addrMapMaxSize {
+				addrMap.Store(dstAddr.String(), datagram.Header)
+				addrMapLen.Add(1)
+			}
 			ws, err := udpConn.WriteToUDP(datagram.Payload, dstAddr)
 			if err != nil {
 				log.Debugf("UDP associate [%v - %v] WriteToUDP() failed: %v", udpConn.LocalAddr(), dstAddr, err)
@@ -84,15 +111,14 @@ func RunUDPAssociateLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStreamT
 	// Packets from mieru proxy server -> socks5 proxy client.
 	go func() {
 		defer wg.Done()
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		var n int
 		var addr *net.UDPAddr
 		var err error
 		for {
 			n, addr, err = udpConn.ReadFromUDP(buf)
 			if err != nil {
-				// This is typically due to close of UDP listener.
-				// Don't contribute to UDPAssociateErrors.
 				if !stderror.IsEOF(err) && !stderror.IsClosed(err) {
 					log.Debugf("UDP associate %v Read() failed: %v", udpConn.LocalAddr(), err)
 				}
@@ -108,8 +134,13 @@ func RunUDPAssociateLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStreamT
 			} else {
 				header = udpAddrToHeader(addr)
 				addrMap.Store(addr.String(), header)
+				addrMapLen.Add(1)
 			}
-			_, err = conn.Write(append(append([]byte(nil), header...), buf[:n]...))
+			writeBuf := pool.GetBuf64k()
+			n2 := copy(writeBuf, header)
+			n2 += copy(writeBuf[n2:], buf[:n])
+			_, err = conn.Write(writeBuf[:n2])
+			pool.PutBuf64k(writeBuf)
 			if err != nil {
 				log.Debugf("UDP associate %v Write() to proxy client failed: %v", udpConn.LocalAddr(), err)
 				if udpErr.Load() == nil {
@@ -123,7 +154,11 @@ func RunUDPAssociateLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStreamT
 	}()
 
 	wg.Wait()
-	return udpErr.Load().(error)
+	close(cleanupDone)
+	if err := udpErr.Load(); err != nil {
+		return err.(error)
+	}
+	return nil
 }
 
 // RunUDPForwardingLoop exchanges socks5 UDP packets between a mieru proxy client and a socks5 proxy server,
@@ -137,8 +172,9 @@ func RunUDPForwardingLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStream
 	// Monitor TCP connection for closure (signals end of socks5 UDP association).
 	go func() {
 		defer wg.Done()
-		buf := make([]byte, 1)
-		_, err := ctrlConn.Read(buf)
+		buf := pool.GetBuf1k()
+		defer pool.PutBuf1k(buf)
+		_, err := ctrlConn.Read(buf[:1])
 		if err != nil {
 			if udpErr.Load() == nil {
 				udpErr.Store(err)
@@ -152,7 +188,8 @@ func RunUDPForwardingLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStream
 	go func() {
 		defer wg.Done()
 		defer udpConn.Close()
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		for {
 			n, err := conn.Read(buf)
 			if err != nil {
@@ -175,7 +212,8 @@ func RunUDPForwardingLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStream
 	// Packets from socks5 proxy server -> mieru proxy client.
 	go func() {
 		defer wg.Done()
-		buf := make([]byte, 1<<16)
+		buf := pool.GetBuf64k()
+		defer pool.PutBuf64k(buf)
 		for {
 			n, _, err := udpConn.ReadFromUDP(buf)
 			if err != nil {
@@ -202,8 +240,8 @@ func RunUDPForwardingLoop(udpConn *net.UDPConn, conn *apicommon.PacketOverStream
 
 	wg.Wait()
 	ctrlConn.Close()
-	if err := udpErr.Load(); err != nil {
-		return err.(error)
+	if v := udpErr.Load(); v != nil {
+		return v.(error)
 	}
 	return nil
 }
@@ -230,8 +268,9 @@ func runUDPAssociateDatagramLoop(udpConn *net.UDPConn, ctrlConn net.Conn, resolv
 	}()
 
 	var clientAddr *net.UDPAddr
-	targetAddrs := make(map[string]struct{})
-	buf := make([]byte, 1<<16)
+	targetAddrs := make(map[string]struct{}, 256)
+	buf := pool.GetBuf64k()
+	defer pool.PutBuf64k(buf)
 	for {
 		n, addr, err := udpConn.ReadFromUDP(buf)
 		if err != nil {
@@ -262,7 +301,10 @@ func runUDPAssociateDatagramLoop(udpConn *net.UDPConn, ctrlConn net.Conn, resolv
 				UDPAssociateErrors.Add(1)
 				continue
 			}
-			targetAddrs[dstAddr.String()] = struct{}{}
+			// Limit targetAddrs to prevent unbounded growth.
+			if len(targetAddrs) < 4096 {
+				targetAddrs[dstAddr.String()] = struct{}{}
+			}
 			UDPAssociateUploadPackets.Add(1)
 			UDPAssociateUploadBytes.Add(int64(ws))
 			continue


### PR DESCRIPTION
The main leak was that StreamUnderlay.Close() and PacketUnderlay.Close()
called SetDeadline() to unblock I/O but never called conn.Close(),
causing every SOCKS5 request to leave an ESTABLISHED TCP connection
forever after the session was closed.

Additional fixes:
- Clean up addrMap entries in UDP associate loop on each cleanup tick
  instead of only resetting the counter, preventing unbounded map growth
- Replace time.After() with time.NewTimer() + defer timer.Stop() to
  prevent Go runtime timer accumulation
- Add buffer pools (64KB, 1KB, 1500B, 32B) for frequently allocated
  buffers to reduce GC pressure
- Fix goroutine leak in socks5 acceptLoop by using non-blocking sends
  and sync.WaitGroup for UDP goroutines
- Add segment pool in protocol/segment.go
- Bound cipher cache at 65536 entries with stale entry cleanup
- Fix UDP socket leak in common/dialer.go when ApplyUDPControl fails

Closes #273 (memory leak when user count is high)