### PR TITLE
fix: add idle read deadline to BidiCopy to prevent connection leak when upstream is unresponsive

### DIFF
--- a/pkg/common/copy.go
+++ b/pkg/common/copy.go
@@ -17,18 +17,67 @@ package common
 
 import (
 	"io"
+	"net"
+	"time"
 )
 
+const DefaultIdleTimeout = 15 * time.Minute
+
+type setReadDeadliner interface {
+	SetReadDeadline(t time.Time) error
+}
+
+// timeoutReader wraps a reader and sets a read deadline on the underlying
+// connection before each read. This prevents io.Copy from hanging forever
+// when the remote end accepts the TCP connection but never sends data.
+type timeoutReader struct {
+	r       io.Reader
+	timeout time.Duration
+	conn    setReadDeadliner
+}
+
+func (tr *timeoutReader) Read(p []byte) (int, error) {
+	tr.conn.SetReadDeadline(time.Now().Add(tr.timeout))
+	return tr.r.Read(p)
+}
+
 // BidiCopy does bi-directional data copy.
+// An idle timeout of DefaultIdleTimeout is applied to prevent hanging on
+// connections that accept TCP but never send data.
+// This timeout resets on each successful read, so active transfers are not
+// affected.
 func BidiCopy(conn1, conn2 io.ReadWriteCloser) error {
+	return bidiCopyWithTimeout(conn1, conn2, DefaultIdleTimeout)
+}
+
+func bidiCopyWithTimeout(conn1, conn2 io.ReadWriteCloser, idleTimeout time.Duration) error {
 	errCh := make(chan error, 2)
+
+	var deadline1, deadline2 setReadDeadliner
+	if idleTimeout > 0 {
+		if c, ok := conn1.(net.Conn); ok {
+			deadline1 = c
+		}
+		if c, ok := conn2.(net.Conn); ok {
+			deadline2 = c
+		}
+	}
+
 	go func() {
-		_, err := io.Copy(conn1, conn2)
+		r := io.Reader(conn2)
+		if deadline2 != nil {
+			r = &timeoutReader{r: conn2, timeout: idleTimeout, conn: deadline2}
+		}
+		_, err := io.Copy(conn1, r)
 		conn1.Close()
 		errCh <- err
 	}()
 	go func() {
-		_, err := io.Copy(conn2, conn1)
+		r := io.Reader(conn1)
+		if deadline1 != nil {
+			r = &timeoutReader{r: conn1, timeout: idleTimeout, conn: deadline1}
+		}
+		_, err := io.Copy(conn2, r)
 		conn2.Close()
 		errCh <- err
 	}()

--- a/pkg/common/copy.go
+++ b/pkg/common/copy.go
@@ -23,29 +23,44 @@ import (
 
 const DefaultIdleTimeout = 15 * time.Minute
 
-type setReadDeadliner interface {
-	SetReadDeadline(t time.Time) error
-}
-
-// timeoutReader wraps a reader and sets a read deadline on the underlying
-// connection before each read. This prevents io.Copy from hanging forever
-// when the remote end accepts the TCP connection but never sends data.
-type timeoutReader struct {
-	r       io.Reader
+// TimeoutConn wraps a net.Conn and sets a combined read+write deadline
+// before every Read or Write call. Any I/O activity on the connection
+// resets the idle timer for both directions. This prevents the quiet
+// side of an asymmetric transfer from expiring while the other side
+// is still actively transferring data.
+type TimeoutConn struct {
+	net.Conn
 	timeout time.Duration
-	conn    setReadDeadliner
 }
 
-func (tr *timeoutReader) Read(p []byte) (int, error) {
-	tr.conn.SetReadDeadline(time.Now().Add(tr.timeout))
-	return tr.r.Read(p)
+// NewTimeoutConn creates a TimeoutConn that resets both read and write
+// deadlines on any I/O activity.
+func NewTimeoutConn(conn net.Conn, timeout time.Duration) *TimeoutConn {
+	return &TimeoutConn{Conn: conn, timeout: timeout}
+}
+
+func (c *TimeoutConn) Read(p []byte) (int, error) {
+	c.Conn.SetDeadline(time.Now().Add(c.timeout))
+	return c.Conn.Read(p)
+}
+
+func (c *TimeoutConn) Write(p []byte) (int, error) {
+	c.Conn.SetDeadline(time.Now().Add(c.timeout))
+	return c.Conn.Write(p)
+}
+
+// Close is provided to satisfy io.ReadWriteCloser. It delegates to the
+// underlying net.Conn.Close().
+func (c *TimeoutConn) Close() error {
+	return c.Conn.Close()
 }
 
 // BidiCopy does bi-directional data copy.
 // An idle timeout of DefaultIdleTimeout is applied to prevent hanging on
 // connections that accept TCP but never send data.
-// This timeout resets on each successful read, so active transfers are not
-// affected.
+// Any I/O activity (read or write) on either connection resets the deadline
+// for both directions, so long-lived asymmetric transfers are not killed
+// by the quiet side timing out.
 func BidiCopy(conn1, conn2 io.ReadWriteCloser) error {
 	return bidiCopyWithTimeout(conn1, conn2, DefaultIdleTimeout)
 }
@@ -53,31 +68,23 @@ func BidiCopy(conn1, conn2 io.ReadWriteCloser) error {
 func bidiCopyWithTimeout(conn1, conn2 io.ReadWriteCloser, idleTimeout time.Duration) error {
 	errCh := make(chan error, 2)
 
-	var deadline1, deadline2 setReadDeadliner
+	// Wrap connections with idle timeout if they support it.
 	if idleTimeout > 0 {
 		if c, ok := conn1.(net.Conn); ok {
-			deadline1 = c
+			conn1 = NewTimeoutConn(c, idleTimeout)
 		}
 		if c, ok := conn2.(net.Conn); ok {
-			deadline2 = c
+			conn2 = NewTimeoutConn(c, idleTimeout)
 		}
 	}
 
 	go func() {
-		r := io.Reader(conn2)
-		if deadline2 != nil {
-			r = &timeoutReader{r: conn2, timeout: idleTimeout, conn: deadline2}
-		}
-		_, err := io.Copy(conn1, r)
+		_, err := io.Copy(conn1, conn2)
 		conn1.Close()
 		errCh <- err
 	}()
 	go func() {
-		r := io.Reader(conn1)
-		if deadline1 != nil {
-			r = &timeoutReader{r: conn1, timeout: idleTimeout, conn: deadline1}
-		}
-		_, err := io.Copy(conn2, r)
+		_, err := io.Copy(conn2, conn1)
 		conn2.Close()
 		errCh <- err
 	}()

--- a/pkg/socks5/copy.go
+++ b/pkg/socks5/copy.go
@@ -20,12 +20,26 @@ import (
 	"io"
 	"net"
 	"sync/atomic"
+	"time"
 
 	apicommon "github.com/enfein/mieru/v3/apis/common"
 	"github.com/enfein/mieru/v3/apis/model"
+	"github.com/enfein/mieru/v3/pkg/common"
 	"github.com/enfein/mieru/v3/pkg/log"
 	"github.com/enfein/mieru/v3/pkg/stderror"
 )
+
+// timeoutReader wraps a net.Conn and sets a read deadline before each read.
+type timeoutReader struct {
+	r       io.Reader
+	conn    net.Conn
+	timeout time.Duration
+}
+
+func (tr *timeoutReader) Read(p []byte) (int, error) {
+	tr.conn.SetReadDeadline(time.Now().Add(tr.timeout))
+	return tr.r.Read(p)
+}
 
 // BidiCopyUDP does bi-directional data copy between a proxy client UDP endpoint
 // and the proxy tunnel.
@@ -107,6 +121,12 @@ func BidiCopyUDP(udpConn *net.UDPConn, tunnelConn *apicommon.PacketOverStreamTun
 func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error {
 	errCh := make(chan error, 2)
 
+	// Apply idle timeout to prevent hanging on unresponsive connections.
+	var proxyNet, connNet net.Conn
+	var idleTimeout time.Duration = common.DefaultIdleTimeout
+	proxyNet, _ = proxyConn.(net.Conn)
+	connNet, _ = conn.(net.Conn)
+
 	go func() {
 		// conn -> proxyConn
 		buf := make([]byte, 1<<16)
@@ -115,7 +135,11 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 			log.Debugf("HANDSHAKE_NO_WAIT mode socks5 client request: %v", pendingReq)
 			reqLen = copy(buf, pendingReq)
 		}
-		n, err := conn.Read(buf[reqLen:])
+		reader := io.Reader(conn)
+		if connNet != nil {
+			reader = &timeoutReader{r: conn, conn: connNet, timeout: idleTimeout}
+		}
+		n, err := reader.Read(buf[reqLen:])
 		if err != nil {
 			proxyConn.Close()
 			errCh <- fmt.Errorf("failed to read connection request from the client: %w", err)
@@ -128,21 +152,33 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 			errCh <- fmt.Errorf("failed to write connection request to the server: %w", err)
 			return
 		}
-		_, err = io.Copy(proxyConn, conn)
+		reader = io.Reader(conn)
+		if connNet != nil {
+			reader = &timeoutReader{r: conn, conn: connNet, timeout: idleTimeout}
+		}
+		_, err = io.Copy(proxyConn, reader)
 		proxyConn.Close()
 		errCh <- err
 	}()
 
 	go func() {
 		// proxyConn -> conn
-		connResp, err := model.ReadSocks5Response(proxyConn)
+		reader := io.Reader(proxyConn)
+		if proxyNet != nil {
+			reader = &timeoutReader{r: proxyConn, conn: proxyNet, timeout: idleTimeout}
+		}
+		connResp, err := model.ReadSocks5Response(reader)
 		if err != nil {
 			conn.Close()
 			errCh <- fmt.Errorf("failed to read connection response from the server: %w", err)
 			return
 		}
 		log.Debugf("HANDSHAKE_NO_WAIT mode socks5 server reply: %v", connResp.Raw)
-		_, err = io.Copy(conn, proxyConn)
+		reader = io.Reader(proxyConn)
+		if proxyNet != nil {
+			reader = &timeoutReader{r: proxyConn, conn: proxyNet, timeout: idleTimeout}
+		}
+		_, err = io.Copy(conn, reader)
 		conn.Close()
 		errCh <- err
 	}()

--- a/pkg/socks5/copy.go
+++ b/pkg/socks5/copy.go
@@ -29,18 +29,6 @@ import (
 	"github.com/enfein/mieru/v3/pkg/stderror"
 )
 
-// timeoutReader wraps a net.Conn and sets a read deadline before each read.
-type timeoutReader struct {
-	r       io.Reader
-	conn    net.Conn
-	timeout time.Duration
-}
-
-func (tr *timeoutReader) Read(p []byte) (int, error) {
-	tr.conn.SetReadDeadline(time.Now().Add(tr.timeout))
-	return tr.r.Read(p)
-}
-
 // BidiCopyUDP does bi-directional data copy between a proxy client UDP endpoint
 // and the proxy tunnel.
 func BidiCopyUDP(udpConn *net.UDPConn, tunnelConn *apicommon.PacketOverStreamTunnel) error {
@@ -122,10 +110,21 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 	errCh := make(chan error, 2)
 
 	// Apply idle timeout to prevent hanging on unresponsive connections.
+	// Use TimeoutConn which resets both read+write deadlines on any I/O activity,
+	// so asymmetric transfers (e.g. long download with no upload) are not killed.
 	var proxyNet, connNet net.Conn
 	var idleTimeout time.Duration = common.DefaultIdleTimeout
 	proxyNet, _ = proxyConn.(net.Conn)
 	connNet, _ = conn.(net.Conn)
+
+	// Wrap connections with timeout if available.
+	var wrappedConn, wrappedProxy io.ReadWriteCloser = conn, proxyConn
+	if connNet != nil {
+		wrappedConn = common.NewTimeoutConn(connNet, idleTimeout)
+	}
+	if proxyNet != nil {
+		wrappedProxy = common.NewTimeoutConn(proxyNet, idleTimeout)
+	}
 
 	go func() {
 		// conn -> proxyConn
@@ -135,11 +134,7 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 			log.Debugf("HANDSHAKE_NO_WAIT mode socks5 client request: %v", pendingReq)
 			reqLen = copy(buf, pendingReq)
 		}
-		reader := io.Reader(conn)
-		if connNet != nil {
-			reader = &timeoutReader{r: conn, conn: connNet, timeout: idleTimeout}
-		}
-		n, err := reader.Read(buf[reqLen:])
+		n, err := wrappedConn.Read(buf[reqLen:])
 		if err != nil {
 			proxyConn.Close()
 			errCh <- fmt.Errorf("failed to read connection request from the client: %w", err)
@@ -152,33 +147,21 @@ func BidiCopySocks5(conn, proxyConn io.ReadWriteCloser, pendingReq []byte) error
 			errCh <- fmt.Errorf("failed to write connection request to the server: %w", err)
 			return
 		}
-		reader = io.Reader(conn)
-		if connNet != nil {
-			reader = &timeoutReader{r: conn, conn: connNet, timeout: idleTimeout}
-		}
-		_, err = io.Copy(proxyConn, reader)
+		_, err = io.Copy(proxyConn, wrappedConn)
 		proxyConn.Close()
 		errCh <- err
 	}()
 
 	go func() {
 		// proxyConn -> conn
-		reader := io.Reader(proxyConn)
-		if proxyNet != nil {
-			reader = &timeoutReader{r: proxyConn, conn: proxyNet, timeout: idleTimeout}
-		}
-		connResp, err := model.ReadSocks5Response(reader)
+		connResp, err := model.ReadSocks5Response(wrappedProxy)
 		if err != nil {
 			conn.Close()
 			errCh <- fmt.Errorf("failed to read connection response from the server: %w", err)
 			return
 		}
 		log.Debugf("HANDSHAKE_NO_WAIT mode socks5 server reply: %v", connResp.Raw)
-		reader = io.Reader(proxyConn)
-		if proxyNet != nil {
-			reader = &timeoutReader{r: proxyConn, conn: proxyNet, timeout: idleTimeout}
-		}
-		_, err = io.Copy(conn, reader)
+		_, err = io.Copy(conn, wrappedProxy)
 		conn.Close()
 		errCh <- err
 	}()


### PR DESCRIPTION
...