### PR TITLE
fix: normalize proxied SOCKS5 UDP associate endpoint

### DIFF
--- a/pkg/socks5/handler.go
+++ b/pkg/socks5/handler.go
@@ -235,8 +235,15 @@ func (s *Server) handleForwarding(req *model.Request, proxyConn net.Conn, proxy 
 }
 
 func (s *Server) handleForwardingUDP(req *model.Request, proxyConn, egressConn net.Conn) error {
-	// Write UDP associate request to downstream server.
-	if _, err := egressConn.Write(req.Raw); err != nil {
+	// Mita creates a new UDP socket for the downstream proxy, so the client's
+	// requested endpoint does not describe the source of those datagrams. Ask
+	// the downstream proxy to learn Mita's UDP endpoint from the association
+	// instead. Each UDP datagram still carries its actual destination address.
+	downstreamReq := &model.Request{
+		Command: constant.Socks5UDPAssociateCmd,
+		DstAddr: model.AddrSpec{IP: net.IPv4zero, Port: 0},
+	}
+	if err := downstreamReq.WriteToSocks5(egressConn); err != nil {
 		HandshakeErrors.Add(1)
 		egressConn.Close()
 		return fmt.Errorf("failed to write socks5 request to egress proxy: %w", err)

--- a/pkg/socks5/handler_test.go
+++ b/pkg/socks5/handler_test.go
@@ -586,6 +586,14 @@ func TestHandleForwardingUDP(t *testing.T) {
 			t.Errorf("expected UDP associate command, got %v", reqHeader[1])
 			return
 		}
+		wantReqHeader := []byte{
+			constant.Socks5Version, constant.Socks5UDPAssociateCmd, 0, constant.Socks5IPv4Address,
+			0, 0, 0, 0, 0, 0,
+		}
+		if !bytes.Equal(reqHeader, wantReqHeader) {
+			t.Errorf("downstream got UDP associate request %v, want %v", reqHeader, wantReqHeader)
+			return
+		}
 
 		// Create a UDP listener for the socks5 UDP relay.
 		downstreamUDP, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})


### PR DESCRIPTION
## Summary

- send an unspecified `0.0.0.0:0` endpoint in the downstream SOCKS5 UDP ASSOCIATE request
- keep the real destination in each SOCKS5 UDP datagram header
- extend the forwarding integration test so a concrete client endpoint cannot be forwarded unchanged

## Why

Mita allocates a new UDP socket after opening the downstream SOCKS5 association. The endpoint supplied by the upstream client therefore does not identify the source of Mita's downstream UDP datagrams. Strict SOCKS5 servers such as Xray bind the association to that supplied endpoint and reject Mita's packets when the endpoints differ.

Using an unspecified endpoint lets the downstream proxy learn Mita's actual UDP source while preserving destination routing in the per-datagram headers.

Fixes #302.

## Testing

- `CGO_ENABLED=0 go test ./...`
- reproduced the failure with Mita 3.36.0 and Xray 26.6.27
- verified ordinary UDP and representative UDP DHT policy through a Karing -> Mieru TCP -> patched Mita -> Xray laboratory chain
- completed 64 concurrent streams from 32 distinct Karing clients under the same isolated test fixture
