### PR TITLE
fix(metrics): publish checkpoints atomically

### DIFF
--- a/pkg/metrics/checkpoint.go
+++ b/pkg/metrics/checkpoint.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2026  mieru authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// The boundary keeps publication and cleanup identical for real I/O and
+// injected filesystem failures. No global hooks or extra writer goroutines.
+type checkpointFile interface {
+	io.Writer
+	Name() string
+	Chmod(os.FileMode) error
+	Sync() error
+	Close() error
+}
+
+type checkpointFileOps struct {
+	createTemp func(dir, pattern string) (checkpointFile, error)
+	rename     func(from, to string) error
+	openDir    func(dir string) (checkpointFile, error)
+}
+
+// writeCheckpointFile publishes a complete file on the local server filesystem.
+// The caller serializes snapshot collection and this entire operation. It is
+// not a cross-process lock, nor a substitute for stopping byte producers.
+func writeCheckpointFile(path string, data []byte, ops checkpointFileOps) (err error) {
+	mode := os.FileMode(0600)
+	info, statErr := os.Lstat(path)
+	if statErr == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("checkpoint destination is not a regular file")
+		}
+		mode = info.Mode().Perm()
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("stat checkpoint: %w", statErr)
+	}
+	dir := filepath.Dir(path)
+	directory, err := ops.openDir(dir)
+	if err != nil {
+		return fmt.Errorf("open checkpoint directory: %w", err)
+	}
+	defer func() {
+		if closeErr := directory.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close checkpoint directory: %w", closeErr))
+		}
+	}()
+	f, err := ops.createTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary checkpoint: %w", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			if closeErr := f.Close(); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("close temporary checkpoint: %w", closeErr))
+			}
+		}
+		if removeErr := os.Remove(f.Name()); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, fmt.Errorf("remove temporary checkpoint: %w", removeErr))
+		}
+	}()
+	n, err := f.Write(data)
+	if err != nil {
+		return fmt.Errorf("write temporary checkpoint: %w", err)
+	}
+	if n != len(data) {
+		return fmt.Errorf("write temporary checkpoint: %w", io.ErrShortWrite)
+	}
+	if err := f.Chmod(mode); err != nil {
+		return fmt.Errorf("set checkpoint permissions: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync temporary checkpoint: %w", err)
+	}
+	closed = true
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temporary checkpoint: %w", err)
+	}
+	if err := ops.rename(f.Name(), path); err != nil {
+		return fmt.Errorf("publish checkpoint: %w", err)
+	}
+	if err := directory.Sync(); err != nil {
+		// Rename already happened. Never restore an older file or claim that
+		// this error means nothing was published.
+		return fmt.Errorf("checkpoint published but directory sync failed; crash durability uncertain: %w", err)
+	}
+	return nil
+}

--- a/pkg/metrics/checkpoint_concurrency_test.go
+++ b/pkg/metrics/checkpoint_concurrency_test.go
@@ -1,0 +1,195 @@
+// Copyright (C) 2026  mieru authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pb "github.com/enfein/mieru/v3/pkg/metrics/metricspb"
+	"google.golang.org/protobuf/proto"
+)
+
+type checkpointPauseMetric struct {
+	value    atomic.Int64
+	loads    atomic.Int64
+	captured chan struct{}
+	release  chan struct{}
+}
+
+func (*checkpointPauseMetric) Name() string        { return "bytes" }
+func (*checkpointPauseMetric) Type() MetricType    { return COUNTER }
+func (m *checkpointPauseMetric) Add(n int64) int64 { return m.value.Add(n) }
+func (m *checkpointPauseMetric) Store(n int64)     { m.value.Store(n) }
+func (m *checkpointPauseMetric) Load() int64 {
+	n := m.value.Load()
+	if m.loads.Add(1) == 1 {
+		close(m.captured)
+		<-m.release
+	}
+	return n
+}
+
+func installCheckpointPauseMetric(t *testing.T) (*checkpointPauseMetric, func()) {
+	t.Helper()
+	m := &checkpointPauseMetric{captured: make(chan struct{}), release: make(chan struct{})}
+	g := &MetricGroup{name: "checkpoint-concurrency-test"}
+	g.metrics.Store(m.Name(), m)
+	metricMap.Store(g.name, g)
+	var once sync.Once
+	release := func() { once.Do(func() { close(m.release) }) }
+	t.Cleanup(func() {
+		release()
+		metricMap.Delete(g.name)
+	})
+	return m, release
+}
+
+func waitForCheckpointPause(t *testing.T, m *checkpointPauseMetric) {
+	t.Helper()
+	select {
+	case <-m.captured:
+	case <-time.After(5 * time.Second):
+		t.Fatal("checkpoint did not reach collection barrier")
+	}
+}
+
+func setCheckpointPath(t *testing.T, path string) {
+	t.Helper()
+	logMutex.Lock()
+	previous := metricsDumpFilePath
+	logMutex.Unlock()
+	SetMetricsDumpFilePath(path)
+	t.Cleanup(func() { SetMetricsDumpFilePath(previous) })
+}
+
+func TestLoadWaitsForCheckpointPublication(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.pb")
+	setCheckpointPath(t, path)
+	empty, err := proto.Marshal(&pb.AllMetrics{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, empty, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m, release := installCheckpointPauseMetric(t)
+	dumpDone := make(chan error, 1)
+	go func() { dumpDone <- DumpMetricsNow() }()
+	waitForCheckpointPause(t, m)
+
+	loadDone := make(chan error, 1)
+	go func() { loadDone <- LoadMetricsFromDump() }()
+	select {
+	case err := <-loadDone:
+		t.Fatalf("load completed while checkpoint publication was paused: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	for name, done := range map[string]chan error{"dump": dumpDone, "load": loadDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s failed: %v", name, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s did not finish", name)
+		}
+	}
+}
+
+func TestCheckpointSerializesCollectionThroughPublication(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.pb")
+	setCheckpointPath(t, path)
+	m, release := installCheckpointPauseMetric(t)
+	m.value.Store(100)
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- DumpMetricsNow() }()
+	waitForCheckpointPause(t, m)
+	m.value.Store(200)
+
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- DumpMetricsNow() }()
+	select {
+	case err := <-secondDone:
+		release()
+		<-firstDone
+		t.Fatalf("newer checkpoint completed while older collection was paused: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+	for name, done := range map[string]chan error{"first": firstDone, "second": secondDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s checkpoint failed: %v", name, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s checkpoint did not finish", name)
+		}
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &pb.AllMetrics{}
+	if err := proto.Unmarshal(b, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	for _, group := range snapshot.GetGroups() {
+		if group.GetName() != "checkpoint-concurrency-test" {
+			continue
+		}
+		for _, metric := range group.GetMetrics() {
+			if metric.GetName() == m.Name() {
+				if metric.GetValue() != 200 {
+					t.Fatalf("persisted %d, want 200", metric.GetValue())
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("checkpoint test metric missing")
+}
+
+func TestCheckpointPublishesToPathCapturedBeforeCollection(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.pb")
+	second := filepath.Join(dir, "second.pb")
+	setCheckpointPath(t, first)
+
+	m, release := installCheckpointPauseMetric(t)
+	done := make(chan error, 1)
+	go func() { done <- DumpMetricsNow() }()
+	waitForCheckpointPause(t, m)
+	SetMetricsDumpFilePath(second)
+	release()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("checkpoint did not finish")
+	}
+	if _, err := os.Stat(first); err != nil {
+		t.Fatalf("checkpoint was not published to captured path: %v", err)
+	}
+	if _, err := os.Stat(second); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint followed a concurrent path change: %v", err)
+	}
+}

--- a/pkg/metrics/checkpoint_file_test.go
+++ b/pkg/metrics/checkpoint_file_test.go
@@ -1,0 +1,223 @@
+// Copyright (C) 2026  mieru authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package metrics
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/enfein/mieru/v3/pkg/metrics/metricspb"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCheckpointReplacesFileWithoutMutatingExistingReader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.pb")
+	setCheckpointPath(t, path)
+	old, err := proto.Marshal(&pb.AllMetrics{Groups: []*pb.MetricGroup{{Name: proto.String("old-checkpoint")}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, old, 0640); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	if err := DumpMetricsNow(); err != nil {
+		t.Fatal(err)
+	}
+	stillOld, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(old, stillOld) {
+		t.Fatal("checkpoint rewrote the inode held by an existing reader")
+	}
+	fresh, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(old, fresh) {
+		t.Fatal("checkpoint did not publish a new snapshot")
+	}
+	if err := proto.Unmarshal(fresh, &pb.AllMetrics{}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0640 {
+		t.Fatalf("checkpoint permissions %o, want 0640", info.Mode().Perm())
+	}
+}
+
+func TestCheckpointRejectsSymlinkWithoutTouchingTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.pb")
+	setCheckpointPath(t, path)
+	target := filepath.Join(dir, "unrelated")
+	if err := os.WriteFile(target, []byte("leave this alone"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := DumpMetricsNow(); err == nil {
+		t.Fatal("checkpoint followed a symlink")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "leave this alone" {
+		t.Fatal("symlink target changed")
+	}
+}
+
+type failingCheckpointFile struct {
+	checkpointFile
+	fail string
+	err  error
+}
+
+func (f failingCheckpointFile) Write(b []byte) (int, error) {
+	if f.fail == "write" {
+		return 0, f.err
+	}
+	if f.fail == "short-write" {
+		return len(b) - 1, nil
+	}
+	return f.checkpointFile.Write(b)
+}
+
+func (f failingCheckpointFile) Chmod(mode os.FileMode) error {
+	if f.fail == "chmod" {
+		return f.err
+	}
+	return f.checkpointFile.Chmod(mode)
+}
+
+func (f failingCheckpointFile) Sync() error {
+	if f.fail == "sync" {
+		return f.err
+	}
+	return f.checkpointFile.Sync()
+}
+
+func (f failingCheckpointFile) Close() error {
+	err := f.checkpointFile.Close()
+	if f.fail == "close" {
+		return f.err
+	}
+	return err
+}
+
+func TestCheckpointPublicationFailures(t *testing.T) {
+	operations := []string{"open-dir", "create", "write", "short-write", "chmod", "sync", "close", "rename", "dir-sync", "dir-close"}
+	for _, operation := range operations {
+		t.Run(operation, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "metrics.pb")
+			old, next := []byte("previous complete checkpoint"), []byte("next complete checkpoint")
+			if err := os.WriteFile(path, old, 0600); err != nil {
+				t.Fatal(err)
+			}
+			injected := errors.New("synthetic checkpoint failure")
+			ops := checkpointFileOps{
+				createTemp: func(dir, pattern string) (checkpointFile, error) {
+					if operation == "create" {
+						return nil, injected
+					}
+					f, err := os.CreateTemp(dir, pattern)
+					if err != nil {
+						return nil, err
+					}
+					return failingCheckpointFile{f, operation, injected}, nil
+				},
+				rename: func(from, to string) error {
+					if operation == "rename" {
+						return injected
+					}
+					return os.Rename(from, to)
+				},
+				openDir: func(dir string) (checkpointFile, error) {
+					if operation == "open-dir" {
+						return nil, injected
+					}
+					f, err := os.Open(dir)
+					if err != nil {
+						return nil, err
+					}
+					failure := ""
+					if operation == "dir-sync" {
+						failure = "sync"
+					}
+					if operation == "dir-close" {
+						failure = "close"
+					}
+					return failingCheckpointFile{f, failure, injected}, nil
+				},
+			}
+			err := writeCheckpointFile(path, next, ops)
+			wantErr := injected
+			if operation == "short-write" {
+				wantErr = io.ErrShortWrite
+			}
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("error %v, want %v", err, wantErr)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := old
+			if operation == "dir-sync" || operation == "dir-close" {
+				want = next
+			}
+			if !bytes.Equal(data, want) {
+				t.Fatalf("published %q, want %q", data, want)
+			}
+			entries, err := os.ReadDir(filepath.Dir(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 1 || entries[0].Name() != "metrics.pb" {
+				t.Fatalf("temporary checkpoint leaked: %v", entries)
+			}
+		})
+	}
+}
+
+func TestCheckpointNewFilePrivateAndComplete(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.pb")
+	setCheckpointPath(t, path)
+	if err := DumpMetricsNow(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("new checkpoint permissions %o, want 0600", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := proto.Unmarshal(data, &pb.AllMetrics{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/metrics/export.go
+++ b/pkg/metrics/export.go
@@ -35,6 +35,10 @@ var metricsDumpFilePath string
 var stopLogging chan struct{}
 var logMutex sync.Mutex
 
+// Serialize collection through publication, not just filesystem writes. An
+// older concurrent snapshot must never replace a newer checkpoint.
+var dumpMutex sync.Mutex
+
 func init() {
 	logDuration = 10 * time.Minute
 	stopLogging = make(chan struct{}, 1) // doesn't block
@@ -104,6 +108,8 @@ func SetMetricsDumpFilePath(path string) {
 }
 
 func LoadMetricsFromDump() error {
+	dumpMutex.Lock()
+	defer dumpMutex.Unlock()
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	if metricsDumpFilePath == "" {
@@ -157,13 +163,16 @@ func LoadMetricsFromDump() error {
 
 // DumpMetricsNow writes the current metrics to the dump file.
 // This function can be called when metrics dump is disabled.
+// It does not stop metric producers or the periodic logging worker.
 func DumpMetricsNow() error {
+	dumpMutex.Lock()
+	defer dumpMutex.Unlock()
 	logMutex.Lock()
-	if metricsDumpFilePath == "" {
-		logMutex.Unlock()
+	path := metricsDumpFilePath
+	logMutex.Unlock()
+	if path == "" {
 		return fmt.Errorf("can't dump metrics: file path is not set")
 	}
-	logMutex.Unlock()
 
 	m := &pb.AllMetrics{}
 	pbGroups := make([]*pb.MetricGroup, 0)
@@ -187,10 +196,11 @@ func DumpMetricsNow() error {
 	if err != nil {
 		return fmt.Errorf("proto.Marshal() failed: %w", err)
 	}
-	if err := os.WriteFile(metricsDumpFilePath, b, 0660); err != nil {
-		return fmt.Errorf("os.WriteFile(%q) failed: %w", metricsDumpFilePath, err)
-	}
-	return nil
+	return writeCheckpointFile(path, b, checkpointFileOps{
+		createTemp: func(dir, pattern string) (checkpointFile, error) { return os.CreateTemp(dir, pattern) },
+		rename:     os.Rename,
+		openDir:    func(dir string) (checkpointFile, error) { return os.Open(dir) },
+	})
 }
 
 // ToMetricPB creates a protobuf representation of a metric.


### PR DESCRIPTION
## Summary

- serialize metric collection through checkpoint publication, including concurrent loads
- capture the destination before collection and atomically replace it with a same-directory temporary file
- fsync the file and parent directory, preserve existing permission bits, and reject non-regular destinations
- cover stale-writer ordering, concurrent load/path changes, open-reader consistency, permissions, symlinks, and injected I/O failures

## Verification

- `go test -race ./pkg/metrics -count=10`
- Linux amd64 and arm64 test binaries compile with `CGO_ENABLED=0`
- `make lib`: format, vet, build, and `pkg/metrics` pass; the repository-wide test step is blocked only by the environment-dependent `apis/common` `invalid_host` DNS cases (`TestResolveTCPAddr` and `TestResolveUDPAddr`)

This change only makes each persisted snapshot ordered and crash-safe. It does not claim to stop metric producers or join server workers during shutdown.