### PR TITLE
fix(protocol): size shared server UDP socket buffers

### DIFF
--- a/pkg/protocol/mux.go
+++ b/pkg/protocol/mux.go
@@ -556,6 +556,10 @@ func (m *Mux) acceptUnderlayLoop(ctx context.Context, properties UnderlayPropert
 			wg.Done()
 			return
 		}
+		if err := configureServerPacketBuffers(conn); err != nil {
+			// Buffer tuning is best-effort; a usable listener must remain available.
+			log.Warnf("Server UDP endpoint %s buffer tuning: %v", laddr, err)
+		}
 		wg.Done()
 		log.Infof("Mux is listening to endpoint %s %s", network, laddr)
 

--- a/pkg/protocol/server_packet_buffer.go
+++ b/pkg/protocol/server_packet_buffer.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026  mieru authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// Shared server listeners receive uploads from many sessions. Leave room for
+// short scheduling pauses without changing client sockets or global sysctls.
+// These are requests, not reservations: the OS may clamp or reject them.
+func configureServerPacketBuffers(conn net.PacketConn) error {
+	var result error
+	if socket, ok := conn.(interface{ SetReadBuffer(int) error }); ok {
+		if err := socket.SetReadBuffer(4 << 20); err != nil {
+			result = fmt.Errorf("set UDP receive buffer: %w", err)
+		}
+	}
+	if socket, ok := conn.(interface{ SetWriteBuffer(int) error }); ok {
+		if err := socket.SetWriteBuffer(1 << 20); err != nil {
+			result = errors.Join(result, fmt.Errorf("set UDP send buffer: %w", err))
+		}
+	}
+	return result
+}

--- a/pkg/protocol/server_packet_buffer_linux_test.go
+++ b/pkg/protocol/server_packet_buffer_linux_test.go
@@ -5,6 +5,7 @@ package protocol
 
 import (
 	"net"
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -66,12 +67,18 @@ func TestServerMuxRetainsPacketBurstDuringReaderPause(t *testing.T) {
 		t.Fatal("server did not attempt to enlarge the receive buffer")
 	}
 	const (
-		packets     = 160
-		packetBytes = 1000
-		// Linux reports SO_RCVBUF as twice the requested capacity to account
-		// for socket bookkeeping. Require that same conservative margin.
-		requiredBuffer = 2 * packets * packetBytes
+		packets               = 160
+		packetBytes           = 1000
+		minPacketMemoryBudget = 8 << 10
 	)
+	// Linux charges queued datagrams by skb->truesize, not wire payload bytes.
+	// Budget two OS pages per packet, with an 8 KiB floor, before running the
+	// fixture against the effective SO_RCVBUF capacity.
+	packetMemoryBudget := 2 * os.Getpagesize()
+	if packetMemoryBudget < minPacketMemoryBudget {
+		packetMemoryBudget = minPacketMemoryBudget
+	}
+	requiredBuffer := packets * packetMemoryBudget
 	effectiveBuffer, err := udpReadBufferSize(raw)
 	if err != nil {
 		t.Fatalf("read effective UDP receive buffer: %v", err)

--- a/pkg/protocol/server_packet_buffer_linux_test.go
+++ b/pkg/protocol/server_packet_buffer_linux_test.go
@@ -1,0 +1,116 @@
+// Copyright (C) 2026  mieru authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package protocol
+
+import (
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type pausedPacketReader struct {
+	*net.UDPConn
+	release       chan struct{}
+	entered       chan struct{}
+	readBufferSet bool
+}
+
+func (c *pausedPacketReader) ReadFrom(b []byte) (int, net.Addr, error) {
+	select {
+	case c.entered <- struct{}{}:
+	default:
+	}
+	<-c.release
+	return c.UDPConn.ReadFrom(b)
+}
+
+func (c *pausedPacketReader) SetReadBuffer(bytes int) error {
+	c.readBufferSet = true
+	return c.UDPConn.SetReadBuffer(bytes)
+}
+
+func udpReadBufferSize(conn *net.UDPConn) (int, error) {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var size int
+	var socketErr error
+	if err := rawConn.Control(func(fd uintptr) {
+		size, socketErr = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	}); err != nil {
+		return 0, err
+	}
+	return size, socketErr
+}
+
+// A short scheduling pause must not drop a modest upload burst on the shared
+// server listener. The factory recreates the production 208 KiB starting buffer;
+// the real Mux must enlarge it before reporting readiness.
+func TestServerMuxRetainsPacketBurstDuringReaderPause(t *testing.T) {
+	raw, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	if err := raw.SetReadBuffer(106496); err != nil {
+		t.Fatal(err)
+	}
+	conn := &pausedPacketReader{UDPConn: raw, release: make(chan struct{}), entered: make(chan struct{}, 1)}
+	// Release the real underlay's reader even when a test assertion fails.
+	defer close(conn.release)
+	startBufferTestMux(t, conn)
+	if !conn.readBufferSet {
+		t.Fatal("server did not attempt to enlarge the receive buffer")
+	}
+	const (
+		packets     = 160
+		packetBytes = 1000
+		// Linux reports SO_RCVBUF as twice the requested capacity to account
+		// for socket bookkeeping. Require that same conservative margin.
+		requiredBuffer = 2 * packets * packetBytes
+	)
+	effectiveBuffer, err := udpReadBufferSize(raw)
+	if err != nil {
+		t.Fatalf("read effective UDP receive buffer: %v", err)
+	}
+	if effectiveBuffer < requiredBuffer {
+		t.Skipf("kernel effective UDP receive buffer is %d bytes; burst test requires at least %d bytes", effectiveBuffer, requiredBuffer)
+	}
+	select {
+	case <-conn.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server packet reader did not start")
+	}
+	sender, err := net.DialUDP("udp4", nil, raw.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sender.Close()
+	payload := make([]byte, packetBytes)
+	for i := 0; i < packets; i++ {
+		payload[0] = byte(i)
+		if _, err := sender.Write(payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := raw.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[byte]bool)
+	for len(seen) < packets {
+		n, _, err := raw.ReadFromUDP(payload)
+		if err != nil {
+			t.Fatalf("shared listener lost upload burst during reader pause: received %d/%d: %v", len(seen), packets, err)
+		}
+		if n != packetBytes || seen[payload[0]] {
+			t.Fatalf("unexpected burst datagram")
+		}
+		seen[payload[0]] = true
+	}
+	if err := raw.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/protocol/server_packet_buffer_test.go
+++ b/pkg/protocol/server_packet_buffer_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2026  mieru authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package protocol
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/enfein/mieru/v3/pkg/common"
+)
+
+type bufferListenerFactory struct {
+	conn net.PacketConn
+}
+
+func (f bufferListenerFactory) ListenPacket(context.Context, string, string) (net.PacketConn, error) {
+	return f.conn, nil
+}
+
+type bufferErrorConn struct {
+	net.PacketConn
+	readErr, writeErr     error
+	readBytes, writeBytes int
+}
+
+func (c *bufferErrorConn) SetReadBuffer(n int) error {
+	c.readBytes = n
+	return c.readErr
+}
+
+func (c *bufferErrorConn) SetWriteBuffer(n int) error {
+	c.writeBytes = n
+	return c.writeErr
+}
+
+func startBufferTestMux(t *testing.T, conn net.PacketConn) *Mux {
+	t.Helper()
+	m := NewMux(false)
+	t.Cleanup(func() { m.Close() })
+	m.SetServerUsers(users)
+	m.SetPacketListenerFactory(bufferListenerFactory{conn})
+	m.SetEndpoints([]UnderlayProperties{NewUnderlayProperties(1400, common.PacketTransport, conn.LocalAddr(), nil)})
+	if err := m.Start(); err != nil {
+		t.Fatalf("server listener rejected usable socket: %v", err)
+	}
+	return m
+}
+
+func TestServerPacketBufferErrorsDoNotPreventStartup(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		readErr, writeErr error
+	}{
+		{"read failure", errors.New("receive buffer rejected"), nil},
+		{"write failure", nil, errors.New("send buffer rejected")},
+		{"both failures", errors.New("receive buffer rejected"), errors.New("send buffer rejected")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { raw.Close() })
+			conn := &bufferErrorConn{PacketConn: raw, readErr: tc.readErr, writeErr: tc.writeErr}
+			startBufferTestMux(t, conn)
+			if conn.readBytes != 4<<20 || conn.writeBytes != 1<<20 {
+				t.Fatalf("server did not attempt both buffers before readiness: receive=%d send=%d", conn.readBytes, conn.writeBytes)
+			}
+		})
+	}
+}
+
+func TestServerPacketBufferOptionalInterfaces(t *testing.T) {
+	raw, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	// An embedding application may provide a PacketConn without socket setters.
+	startBufferTestMux(t, struct{ net.PacketConn }{raw})
+}

--- a/pkg/protocol/server_packet_buffer_test.go
+++ b/pkg/protocol/server_packet_buffer_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/enfein/mieru/v3/pkg/common"
 )
@@ -26,6 +27,28 @@ type bufferErrorConn struct {
 	readBytes, writeBytes int
 }
 
+type blockingBufferConn struct {
+	net.PacketConn
+	blockedSetter          string
+	setterEntered, release chan struct{}
+}
+
+func (c *blockingBufferConn) SetReadBuffer(int) error {
+	if c.blockedSetter == "read" {
+		close(c.setterEntered)
+		<-c.release
+	}
+	return nil
+}
+
+func (c *blockingBufferConn) SetWriteBuffer(int) error {
+	if c.blockedSetter == "write" {
+		close(c.setterEntered)
+		<-c.release
+	}
+	return nil
+}
+
 func (c *bufferErrorConn) SetReadBuffer(n int) error {
 	c.readBytes = n
 	return c.readErr
@@ -36,17 +59,84 @@ func (c *bufferErrorConn) SetWriteBuffer(n int) error {
 	return c.writeErr
 }
 
-func startBufferTestMux(t *testing.T, conn net.PacketConn) *Mux {
+func newBufferTestMux(t *testing.T, conn net.PacketConn) *Mux {
 	t.Helper()
 	m := NewMux(false)
 	t.Cleanup(func() { m.Close() })
 	m.SetServerUsers(users)
 	m.SetPacketListenerFactory(bufferListenerFactory{conn})
 	m.SetEndpoints([]UnderlayProperties{NewUnderlayProperties(1400, common.PacketTransport, conn.LocalAddr(), nil)})
+	return m
+}
+
+func startBufferTestMux(t *testing.T, conn net.PacketConn) *Mux {
+	t.Helper()
+	m := newBufferTestMux(t, conn)
 	if err := m.Start(); err != nil {
 		t.Fatalf("server listener rejected usable socket: %v", err)
 	}
 	return m
+}
+
+func releaseBufferSetter(release chan struct{}) {
+	select {
+	case <-release:
+	default:
+		close(release)
+	}
+}
+
+func requireMuxStartBlocked(t *testing.T, startDone <-chan error, blockedSetter string) {
+	t.Helper()
+	select {
+	case err := <-startDone:
+		t.Fatalf("Mux.Start() returned while the %s buffer setter was blocked: %v", blockedSetter, err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestServerPacketBuffersConfiguredBeforeReadiness(t *testing.T) {
+	for _, blockedSetter := range []string{"read", "write"} {
+		t.Run(blockedSetter, func(t *testing.T) {
+			raw, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { raw.Close() })
+			conn := &blockingBufferConn{
+				PacketConn:    raw,
+				blockedSetter: blockedSetter,
+				setterEntered: make(chan struct{}),
+				release:       make(chan struct{}),
+			}
+			defer releaseBufferSetter(conn.release)
+
+			m := newBufferTestMux(t, conn)
+			startDone := make(chan error, 1)
+			go func() {
+				startDone <- m.Start()
+			}()
+
+			select {
+			case <-conn.setterEntered:
+			case err := <-startDone:
+				t.Fatalf("Mux.Start() returned before the %s buffer setter ran: %v", blockedSetter, err)
+			case <-time.After(time.Second):
+				t.Fatalf("%s buffer setter did not run", blockedSetter)
+			}
+			requireMuxStartBlocked(t, startDone, blockedSetter)
+
+			releaseBufferSetter(conn.release)
+			select {
+			case err := <-startDone:
+				if err != nil {
+					t.Fatalf("Mux.Start() failed after releasing the %s buffer setter: %v", blockedSetter, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("Mux.Start() did not return after releasing the %s buffer setter", blockedSetter)
+			}
+		})
+	}
 }
 
 func TestServerPacketBufferErrorsDoNotPreventStartup(t *testing.T) {


### PR DESCRIPTION
## Problem

The server's shared UDP listener can lose a short burst while its reader is paused if the socket retains a small OS receive buffer. This can happen before packets reach the protocol's own queues.

## Change

- Request a 4 MiB receive buffer and a 1 MiB send buffer immediately after opening a server UDP listener, before reporting readiness.
- Treat both setters as optional and best-effort: attempt both and warn on errors without rejecting an otherwise usable listener.
- Leave client sockets, protocol framing, authentication, congestion control and system-wide socket limits unchanged. The kernel may clamp the requested sizes.

This is a small independent server-side change, not the remainder of a larger downstream branch. It preserves the current upstream metrics/checkpoint and UDP-address changes.

## Regression coverage

- Actual server startup with absent setters and independent/both setter failures.
- Channel-blocked receive/send setters verify that startup does not report readiness while either setter is still running. Moving tuning after readiness makes both tests fail.
- A Linux UDP socket test pauses the listener reader and queues 160 datagrams of 1,000 bytes. It checks that production attempted tuning before checking the kernel's effective receive capacity; it explicitly skips when that capacity is insufficient for the fixture. It does not change sysctls.

## Validation

- Linux/arm64: the full `go test -race -timeout=5m -count=1 ./...` suite passed before the final test-only capacity-guard adjustment. Production code is unchanged by that adjustment.
- Final head: focused Linux race tests passed. The burst fixture explicitly skipped on this Docker kernel (`SO_RCVBUF=425984`, conservative fixture requirement `1310720`); the setter-attempt assertion ran before that skip. Before tightening this guard, the actual same 160-packet fixture passed ten repetitions on this kernel.
- Portable focused race tests passed ten repetitions; moving buffer tuning after readiness made both blocked-setter regression variants fail ten repetitions.
- Host formatting, vet and build passed. The Darwin full test run had the existing `invalid_host` DNS-resolution failures; the isolated Linux full suite above passed those tests.
- Linux/amd64 test compilation passed. No sysctls were changed for these checks.

The repository's Docker basic integration also passed (exit 0): TCP, UDP, handshake-no-wait variants, connection reuse and mixed TCP/UDP SOCKS5 UDP-associate. This used an unchanged client built from stock v3.36.1 (`316cc66`) and the candidate server in an isolated Linux/arm64 container. The final follow-up commit changes only the test's capacity guard, not either binary's production code.

No Internet-latency or universal throughput improvement is claimed: the regression isolates shared-socket burst retention during a reader pause.
